### PR TITLE
Update readme ZSH users

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ echo -e "\nexport PATH=$(pwd)/bin:\$PATH" >> ~/.bashrc
 #### If you use ZSH
 Replace the last line with the following:
 ```sh
-echo "export PATH=$(pwd)/bin/mapf-visualizer.app/Contents/MacOS:\$PATH" >> ~/.zshrc
+echo -e "\nexport PATH=$(pwd)/bin/mapf-visualizer.app/Contents/MacOS:\$PATH" >> ~/.zshrc
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -45,7 +45,17 @@ tar -xzvf third_party/openFrameworks.tar.gz -C third_party --strip-components=1 
 sudo third_party/openFrameworks/scripts/linux/ubuntu/install_dependencies.sh
 sudo third_party/openFrameworks/scripts/linux/ubuntu/install_codecs.sh
 make -j4
-echo "export PATH=$(pwd)/bin:\$PATH" >> ~/.bashrc
+echo -e "\nexport PATH=$(pwd)/bin:\$PATH" >> ~/.bashrc
+```
+
+#### If you use ZSH
+Replace the last line with the following:
+```sh
+echo "export PATH=$(pwd)/bin/mapf-visualizer.app/Contents/MacOS:\$PATH" >> ~/.zshrc
+```
+
+```sh
+echo -e "\nexport PATH=$(pwd)/bin:\$PATH" >> ~/.zshrc
 ```
 
 #### for other Linux
@@ -53,6 +63,9 @@ echo "export PATH=$(pwd)/bin:\$PATH" >> ~/.bashrc
 I heard that the visualizer worked on (Arch) Linux.
 To install, try `install_linux.sh`.
 You may need `sudo`.
+
+#### Note
+The changes will be applied after you restart your terminal. To apply the changes immediately, run `source ~/.bashrc` or `source ~/.zshrc`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ git clone --recursive https://github.com/Kei18/mapf-visualizer.git
 cd mapf-visualizer
 bash third_party/openFrameworks/scripts/osx/download_libs.sh
 make -j4
-echo "export PATH=$(pwd)/bin/mapf-visualizer.app/Contents/MacOS:\$PATH" >> ~/.bashrc
+echo -e "\nexport PATH=$(pwd)/bin/mapf-visualizer.app/Contents/MacOS:\$PATH" >> ~/.bashrc
 ```
 
 required: around 10 minutes


### PR DESCRIPTION
The readme changes do the following:
1. update the installation command for adding the path to ensure it is always added in a new line.
2. add a command for ZSH users
3. add a note to let users note when the changes will be seen. some might get a command not found error even though they had installed it correctly.

it will solve: 
#15 
https://github.com/Kei18/mapf-visualizer/issues/8#issuecomment-2146763125

Note:
@Kei18 
Please test it for Macos once. I was not able to verify it on that.